### PR TITLE
Use `swagger-php` `Generator` to generate the spec

### DIFF
--- a/src/Adapters/AbstractOpenApiResponseVerifier.php
+++ b/src/Adapters/AbstractOpenApiResponseVerifier.php
@@ -2,6 +2,8 @@
 
 namespace Radebatz\OpenApi\Verifier\Adapters;
 
+use OpenApi\Generator;
+
 trait AbstractOpenApiResponseVerifier
 {
     protected function prepareOpenApiSpecificationLoader(string $srcDir, ?string $specification = null)
@@ -33,7 +35,7 @@ trait AbstractOpenApiResponseVerifier
         if (!$specificationLoader) {
             $appRoot = $appRoot ?: $this->getAppRoot();
 
-            $openApi = \OpenApi\scan($appRoot . '/' . $srcDir);
+            $openApi = (new Generator())->generate([$appRoot . '/' . $srcDir]);
             $this->openapiSpecification = json_decode($openApi->toJson());
         }
     }


### PR DESCRIPTION
Replaces the broken code that was still using the old `scan()` function that doesn't exist anym more.